### PR TITLE
Specify uv before python in mise tools

### DIFF
--- a/aoc-main/mise.toml
+++ b/aoc-main/mise.toml
@@ -1,9 +1,11 @@
 [tools]
+# uv before python as mise uses uv to install python
+uv = "0.8.6"
+
 "npm:pyright" = "1.1.403"
 python = "3.13.5"
 "pipx:mypy" = "1.17.1"
 ruff = "0.12.7"
-uv = "0.8.6"
 
 [tasks.check]
 depends = [

--- a/solvers/python/mise.toml
+++ b/solvers/python/mise.toml
@@ -1,9 +1,11 @@
 [tools]
+# uv before python as mise uses uv to install python
+uv = "0.8.6"
+
 "npm:pyright" = "1.1.403"
 python = "3.13.5"
 "pipx:mypy" = "1.17.1"
 ruff = "0.12.7"
-uv = "0.8.6"
 
 [tasks.check]
 depends = [


### PR DESCRIPTION
Mise uses uv to install python and this ideally makes mise use specified uv version to do that.