### PR TITLE
Cache miss on cache-mode=use to not fail

### DIFF
--- a/.github/actions/mise-project-setup/action.yaml
+++ b/.github/actions/mise-project-setup/action.yaml
@@ -27,7 +27,6 @@ runs:
       name: Mise cache restore
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        fail-on-cache-miss: ${{ steps.init.outputs.fail-on-cache-miss }}
         key: ${{ steps.init.outputs.cache-key }}
         path: ${{ steps.init.outputs.cache-paths }}
         restore-keys: ${{ steps.init.outputs.cache-restore-keys }}
@@ -52,6 +51,9 @@ runs:
         DIRECTORIES: ${{ steps.init.outputs.mise-install-directories }}
       run: |
         set -x
+        # Unset in case it is set by an earlier run of this action
+        unset UV_PYTHON_DOWNLOADS
+
         for dir in $DIRECTORIES; do
           echo "::group::Install mise tools: $dir"
           pushd "$dir"

--- a/.github/actions/mise-project-setup/init.sh
+++ b/.github/actions/mise-project-setup/init.sh
@@ -13,11 +13,9 @@ fi
 case "$CACHE_MODE" in
   prepare)
     save_cache=true
-    fail_on_cache_miss=false
     ;;
   use)
     save_cache=false
-    fail_on_cache_miss=true
     ;;
   *)
     echo "::error Unknown cache mode: $CACHE_MODE"
@@ -85,7 +83,6 @@ cargo_home="${RUNNER_TEMP}${SEP}aoc-cargo-home"
 # Set outputs
 {
   echo "cache-key=${cache_key}"
-  echo "fail-on-cache-miss=${fail_on_cache_miss}"
   echo "mise-version=${MISE_VERSION}"
   echo "save-cache=${save_cache}"
 

--- a/.github/actions/uv-project-setup/action.yaml
+++ b/.github/actions/uv-project-setup/action.yaml
@@ -24,7 +24,6 @@ runs:
       id: cache-restore
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        fail-on-cache-miss: ${{ steps.init.outputs.fail-on-cache-miss }}
         key: ${{ steps.init.outputs.cache-key }}
         path: ${{ steps.init.outputs.cache-paths }}
         restore-keys: ${{ steps.init.outputs.cache-restore-keys }}
@@ -36,6 +35,9 @@ runs:
         DIRECTORIES: ${{ steps.init.outputs.uv-install-directories }}
       run: |
         set -x
+        # Unset in case it is set by an earlier run of this action
+        unset UV_OFFLINE
+
         for dir in $DIRECTORIES; do
           echo "::group::Install uv dependencies: $dir"
           pushd "$dir"

--- a/.github/actions/uv-project-setup/init.sh
+++ b/.github/actions/uv-project-setup/init.sh
@@ -5,11 +5,9 @@ set -xe
 case "$CACHE_MODE" in
   prepare)
     save_cache=true
-    fail_on_cache_miss=false
     ;;
   use)
     save_cache=false
-    fail_on_cache_miss=true
     ;;
   *)
     echo "::error Unknown cache mode: $CACHE_MODE"
@@ -74,7 +72,6 @@ uv_cache_dir="${RUNNER_TEMP}/aoc-uv-cache"
 # Set outputs
 {
   echo "cache-key=${cache_key}"
-  echo "fail-on-cache-miss=${fail_on_cache_miss}"
   echo "save-cache=${save_cache}"
 
   # Install directories


### PR DESCRIPTION
Cache save may fail in prepare job as cache saving is considered best effort in Github Actions. And that failure may be accompanied with just a warning and the cache itself may still be reserved for a day. Therefore, failing to restore cache after prepare job is executed should not be a fatal failure. Instead the job should then simply perform without cache in place even though it will take longer.