### PR TITLE
Improve mise cache handling

### DIFF
--- a/.github/actions/mise-project-setup/action.yaml
+++ b/.github/actions/mise-project-setup/action.yaml
@@ -27,11 +27,12 @@ runs:
       name: Mise cache restore
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        key: mise-${{ runner.os }}-${{ steps.init.outputs.mise-version }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('aoc-main/mise.toml', 'solvers/*/mise.toml') }}
+        key: mise-${{ steps.init.outputs.mise-version }}-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('aoc-main/mise.toml') }}-${{ hashFiles('solvers/*/mise.toml') }}
         path: ${{ steps.init.outputs.cache-paths }}
         restore-keys: |
-          mise-${{ runner.os }}-${{ steps.init.outputs.mise-version }}-${{ hashFiles('mise.toml') }}-
-          mise-${{ runner.os }}-${{ steps.init.outputs.mise-version }}-
+          mise-${{ steps.init.outputs.mise-version }}-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('aoc-main/mise.toml') }}-
+          mise-${{ steps.init.outputs.mise-version }}-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
+          mise-${{ steps.init.outputs.mise-version }}-${{ runner.os }}-
 
     - name: Install mise
       uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4

--- a/.github/scripts/delete_obsolete_mise_caches.py
+++ b/.github/scripts/delete_obsolete_mise_caches.py
@@ -14,7 +14,7 @@ def log_group(name: str):
 
 
 with log_group("Fetching list of cache keys"):
-    query_prefix = f"mise-{os.environ['RUNNER_OS']}-"
+    query_prefix = "mise-"
     result = subprocess.run(
         [
             "gh",
@@ -31,7 +31,7 @@ with log_group("Fetching list of cache keys"):
     caches = json.loads(result.stdout)
 
 with log_group("Determining which caches to keep"):
-    keep_prefix = f"mise-{os.environ['RUNNER_OS']}-{os.environ['MISE_VERSION']}-"
+    keep_prefix = f"{query_prefix}{os.environ['MISE_VERSION']}-"
     cacheIdsToDelete = set()
     for item in caches:
         if item["key"].startswith(keep_prefix):

--- a/.github/workflows/cache-cleanup-after-mise-update.yaml
+++ b/.github/workflows/cache-cleanup-after-mise-update.yaml
@@ -8,15 +8,8 @@ permissions: {}
 
 jobs:
   cleanup:
-    strategy:
-      matrix:
-        runner:
-          - macos-15
-          - ubuntu-24.04
-          - windows-2025
-
-    name: Cleanup caches - ${{ matrix.runner }}
-    runs-on: ${{ matrix.runner }}
+    name: Cleanup caches
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     steps:


### PR DESCRIPTION
Adjust cache key so that mise version is before OS. This simplifies cleanup that relies on mise version but not on OS. And OS and mise version don't differ in usage in restore-keys either so this is safe to do.

Change cleanup to run only on one runner to perform cleanup of caches for all OSes. 