### PR TITLE
Use mise upgrade in CI instead of install

### DIFF
--- a/.github/actions/mise-project-setup/action.yaml
+++ b/.github/actions/mise-project-setup/action.yaml
@@ -64,7 +64,7 @@ runs:
         for dir in $DIRECTORIES; do
           echo "::group::Install mise tools: $dir"
           pushd "$dir"
-          mise install
+          mise upgrade
           popd
           echo "::endgroup::"
         done


### PR DESCRIPTION
Mise upgrade automatically reinstall all pipx:* tools if they are connected to the previous python version. Otherwise these commands behave the same in this use case in CI.