### PR TITLE
Use clang-format through pipx/uv

### DIFF
--- a/solvers/cpp/mise.toml
+++ b/solvers/cpp/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-clang-format = "20.1.8"
+"pipx:clang-format" = "20.1.8"
 conan = "2.19.1"
 
 [tasks.check]


### PR DESCRIPTION
Pypi package contains prebuilt binaries unlike the registry version which requires compiling it from sources.