### PR TITLE
ci: Explicitly set mise trusted configs

### DIFF
--- a/.github/actions/mise-project-setup/action.yaml
+++ b/.github/actions/mise-project-setup/action.yaml
@@ -48,6 +48,41 @@ runs:
         version: ${{ steps.init.outputs.mise-version }}
         working_directory: ${{ inputs.directory }}
 
+    - env:
+        DIRECTORIES: ${{ steps.init.outputs.mise-install-directories }}
+      run: |
+        # Set mise trusted config paths
+
+        # Unset MISE_TRUSTED_CONFIG_PATHS for this step
+        unset MISE_TRUSTED_CONFIG_PATHS
+
+        envValues=""
+        for dir in ${DIRECTORIES}; do
+          echo "::group::Set mise trusted config paths: ${dir}"
+          pushd "${dir}"
+          echo "Show trust status before setting"
+          mise trust --show
+          echo "Set as trusted"
+          mise trust .
+          echo "Show trust status after setting"
+          mise trust --show
+          popd
+          echo "::endgroup::"
+
+          if [ -n "${envValues}" ]; then
+            envValues="${envValues}:"
+          fi
+          fullPath=$(realpath .)
+          envValues="${envValues}${fullPath}"
+        done
+
+        echo "::group::Set mise trusted config paths to environment: ${envValues}"
+        {
+          echo "MISE_TRUSTED_CONFIG_PATHS=${envValues}"
+        } | tee -a "${GITHUB_ENV}"
+        echo "::endgroup::"
+      shell: bash
+
     - if: steps.cache-restore.outputs.cache-hit != 'true'
 
       env:


### PR DESCRIPTION
Set mise trusted paths explicitly after installing mise via both the environment variable and mise local configuration. This way the trusted paths should work reliably even if some execution is made with cleared environment variables.