### PR TITLE
Specify --python-version for mypy

### DIFF
--- a/aoc-main/mise.toml
+++ b/aoc-main/mise.toml
@@ -13,8 +13,8 @@ depends = [
 run = """
 # Run mypy
 pythonExecutable=$(uv python find)
-echo "Running mypy with python executable: ${pythonExecutable}"
-mypy --python-executable "${pythonExecutable}" .
+pythonVersion=$(cat pyproject.toml | yq -p toml '.project.requires-python' | sed 's/>=//')
+mypy --python-executable "${pythonExecutable}" --python-version "${pythonVersion}" .
 """
 
 [tasks."check:pyright"]

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ uv = "0.8.24"
 prettier = "3.6.2"
 ruff = "0.13.3"
 shellcheck = "0.11.0"
+yq = "4.47.2"
 
 
 [vars]

--- a/solvers/python/mise.toml
+++ b/solvers/python/mise.toml
@@ -13,8 +13,8 @@ depends = [
 run = """
 # Run mypy
 pythonExecutable=$(uv python find)
-echo "Running mypy with python executable: ${pythonExecutable}"
-mypy --python-executable "${pythonExecutable}" .
+pythonVersion=$(cat pyproject.toml | yq -p toml '.project.requires-python' | sed 's/>=//')
+mypy --python-executable "${pythonExecutable}" --python-version "${pythonVersion}" .
 """
 
 [tasks."check:pyright"]


### PR DESCRIPTION
Mypy would otherwise default to using the python version it is running on. Which is not explicitly set and can be any version that pipx from mise chooses to use, most likely the system installed version. Explicitly specify the same python version as is the minimum supported one in pyproject.toml to ensure mypy doesn't report issues that would only be relevant for older unsupported versions.