### PR TITLE
Remove renovate config check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,13 +76,6 @@ jobs:
       directory: .
       task: check:prettier
 
-  check-renovate-config:
-    needs: mise-cache-ubuntu
-    uses: ./.github/workflows/mise-task.yaml
-    with:
-      directory: .
-      task: check:renovateconfig
-
   check-ruff:
     needs: mise-cache-ubuntu
     uses: ./.github/workflows/mise-task.yaml
@@ -146,7 +139,6 @@ jobs:
     if: always()
     needs:
       - check-prettier
-      - check-renovate-config
       - check-ruff
       - check-ruff-format
       - check-shellcheck

--- a/mise.toml
+++ b/mise.toml
@@ -65,7 +65,6 @@ shell = "sh -c"
 [tasks.check]
 depends = [
   "check:prettier",
-  "check:renovateconfig",
   "check:ruff",
   "check:ruff:format",
   "check:shellcheck",
@@ -93,10 +92,6 @@ if [ -f "$excludesFile" ]; then
 fi
 prettier --ignore-path=.gitignore --ignore-path=.prettierignore "$userIgnoreArg" --check .
 """
-
-[tasks."check:renovateconfig"]
-run = "renovate-config-validator --strict"
-tools."npm:renovate" = "latest"
 
 [tasks."check:ruff"]
 run = "ruff check"


### PR DESCRIPTION
Renovate version used in check is newest version but the hosted renovate runner may use some older version. And the result may be that the newest version reports a need for config migration but the hosted version won't yet support that new config.