### PR TITLE
Pass GITHUB_TOKEN to mise-project-setup action

### DIFF
--- a/.github/actions/mise-project-setup/init.sh
+++ b/.github/actions/mise-project-setup/init.sh
@@ -3,6 +3,11 @@
 set -euo pipefail
 
 # Validate inputs
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "::error::GITHUB_TOKEN environment variable must be set and non-empty"
+  exit 1
+fi
+
 case "${CACHE_MODE}" in
 prepare | use) ;;
 *)

--- a/.github/workflows/cache-cleanup-after-closed-pr.yaml
+++ b/.github/workflows/cache-cleanup-after-closed-pr.yaml
@@ -49,6 +49,9 @@ jobs:
 
       - name: Restore mise tools
         uses: ./.github/actions/mise-project-setup
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           directory: .
 

--- a/.github/workflows/cpp-build-test-run.yaml
+++ b/.github/workflows/cpp-build-test-run.yaml
@@ -90,6 +90,9 @@ jobs:
 
       - name: Setup tools through mise
         uses: ./.github/actions/mise-project-setup
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           directory: solvers/cpp
 

--- a/.github/workflows/mise-prepare-cache.yaml
+++ b/.github/workflows/mise-prepare-cache.yaml
@@ -28,6 +28,9 @@ jobs:
 
       - name: Prepare cache
         uses: ./.github/actions/mise-project-setup
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           cache-mode: prepare
           directory: ""

--- a/.github/workflows/mise-task.yaml
+++ b/.github/workflows/mise-task.yaml
@@ -51,6 +51,9 @@ jobs:
 
       - name: Restore tools
         uses: ./.github/actions/mise-project-setup
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           directory: ${{ inputs.directory }}
 

--- a/.github/workflows/mise-uv-prepare-cache.yaml
+++ b/.github/workflows/mise-uv-prepare-cache.yaml
@@ -39,6 +39,9 @@ jobs:
 
       - name: Restore mise project
         uses: ./.github/actions/mise-project-setup
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           cache-mode: use
           directory: ${{ inputs.directory }}

--- a/.github/workflows/mise-uv-task.yaml
+++ b/.github/workflows/mise-uv-task.yaml
@@ -38,6 +38,9 @@ jobs:
 
       - name: Restore mise project
         uses: ./.github/actions/mise-project-setup
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           directory: ${{ inputs.directory }}
 

--- a/.github/workflows/python-run.yaml
+++ b/.github/workflows/python-run.yaml
@@ -17,6 +17,9 @@ jobs:
 
       - name: Restore mise project
         uses: ./.github/actions/mise-project-setup
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           directory: solvers/python
 

--- a/.github/workflows/rust-build-test-run.yaml
+++ b/.github/workflows/rust-build-test-run.yaml
@@ -45,6 +45,9 @@ jobs:
 
       - name: Setup tools through mise
         uses: ./.github/actions/mise-project-setup
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           directory: solvers/rust
 


### PR DESCRIPTION
Validate also that it has a value in mise-project-setup action. Without it mise randomly but fairly often fails due to GitHub rate-limiting unauthorized requests.