### PR TITLE
Invalidate sanitizer Conan cache on LLVM patch bump

### DIFF
--- a/.github/actions/cmake-project-setup/action.yaml
+++ b/.github/actions/cmake-project-setup/action.yaml
@@ -60,5 +60,6 @@ runs:
         cp .github/files/CMakeUserPresets.json solvers/cpp/
         cp .github/files/conan-profile-clang-with-hardened-libc++ solvers/cpp/
         cp .github/files/conan-profile-clang-with-libc++ solvers/cpp/
+        cp .github/files/conan-profile-clang-with-libc++-sanitizers solvers/cpp/
         cp .github/files/conan-profile-gcc-libstd++-for-clang solvers/cpp/
       shell: bash

--- a/.github/actions/cmake-project-setup/init.sh
+++ b/.github/actions/cmake-project-setup/init.sh
@@ -6,6 +6,11 @@ conanHome=${RUNNER_TEMP}/aoc-conan-home
 
 export CONAN_HOME="${conanHome}"
 
+echo "::group::Install settings_user.yml"
+mkdir -p "${CONAN_HOME}"
+cp "${GITHUB_WORKSPACE}/.github/files/settings_user.yml" "${CONAN_HOME}/"
+echo "::endgroup::"
+
 echo "::group::Detect Conan profile"
 pushd solvers/cpp
 conan profile detect

--- a/.github/actions/homebrew-packages-setup/install.sh
+++ b/.github/actions/homebrew-packages-setup/install.sh
@@ -7,6 +7,8 @@ if [[ -z "${TOOLS_TO_INSTALL}" ]]; then
   exit 1
 fi
 
+llvmFullVersion=""
+
 skipInstalls=false
 if [[ "${INPUT_CACHE_MODE}" == "prepare" && "${GITHUB_EVENT_NAME}" == "pull_request" && "${MATCHED_RESTORE_KEY}" =~ ^"${RESTORE_KEY_PREFIX}" ]]; then
   echo "Prepare mode for PR. Cache restored with a prefix match. Skipping all installs."
@@ -47,6 +49,19 @@ if [[ "${skipInstalls}" == "false" ]]; then
   brew cleanup --scrub
   echo "::endgroup::"
 
+  echo "::group::Determine LLVM full version"
+  brewLlvmListOutput=$(brew list --versions "llvm@${LLVM_MAJOR_VERSION}")
+  if [[ -z "${brewLlvmListOutput}" ]]; then
+    echo "::error::brew list --versions llvm@${LLVM_MAJOR_VERSION} returned empty output"
+    exit 1
+  fi
+  llvmFullVersion=$(echo "${brewLlvmListOutput}" | awk '{print $NF}')
+  if ! [[ "${llvmFullVersion}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "::error::Could not parse LLVM full version from: ${brewLlvmListOutput}"
+    exit 1
+  fi
+  echo "::endgroup::"
+
   echo "::group::Check changes to downloaded contents"
   downloadsHash=$(calculateDownloadsHash)
   echo "downloadsHash=${downloadsHash}"
@@ -70,6 +85,14 @@ else
   downloadsHash=${initialDownloadsHash}
   saveCache=false
 fi
+
+echo "::group::Environment variable changes"
+{
+  if [[ -n "${llvmFullVersion}" ]]; then
+    echo "LLVM_FULL_VERSION=${llvmFullVersion}"
+  fi
+} | tee -a "${GITHUB_ENV}"
+echo "::endgroup::"
 
 echo "::group::Outputs from install"
 {

--- a/.github/files/CMakeUserPresets.json
+++ b/.github/files/CMakeUserPresets.json
@@ -34,7 +34,8 @@
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-O1 -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -fno-optimize-sibling-calls -fno-sanitize-merge $env{PRESET_CXX_FLAGS_GCC_CLANG} $env{PRESET_CXX_FLAGS_LIBCPP_FOR_CLANG}",
         "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined $env{PRESET_LINKER_FLAGS_LIBCPP_FOR_CLANG}",
-        "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=address,undefined $env{PRESET_LINKER_FLAGS_LIBCPP_FOR_CLANG}"
+        "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=address,undefined $env{PRESET_LINKER_FLAGS_LIBCPP_FOR_CLANG}",
+        "CONAN_HOST_PROFILE": "auto-cmake;${sourceDir}/conan-profile-clang-with-libc++-sanitizers"
       }
     },
     {

--- a/.github/files/conan-profile-clang-with-libc++-sanitizers
+++ b/.github/files/conan-profile-clang-with-libc++-sanitizers
@@ -1,0 +1,10 @@
+{# Sanitizer-only profile. Encodes the LLVM patch version into
+   compiler.abi_extra so Conan's package_id changes whenever Homebrew
+   bumps LLVM's patch version, invalidating cached gtest/spdlog binaries
+   whose libc++ ASan-runtime ABI no longer matches. #}
+{% set llvmFullVersion = os.environ["LLVM_FULL_VERSION"] %}
+
+include(conan-profile-clang-with-libc++)
+
+[settings]
+compiler.abi_extra=sanitizers-{{ llvmFullVersion }}

--- a/.github/files/settings_user.yml
+++ b/.github/files/settings_user.yml
@@ -1,0 +1,8 @@
+# Conan 2 settings_user.yml — merged with the built-in settings.yml.
+# Adds an optional free-form ABI tag for clang. Used by sanitizer profiles
+# to encode the LLVM patch version into package_id, so that a Homebrew
+# llvm bump invalidates cached Conan binaries whose libc++/ASan runtime
+# ABI no longer matches the application's.
+compiler:
+  clang:
+    abi_extra: [null, ANY]


### PR DESCRIPTION
The ci-ubuntu-clang-libc++-sanitizers job started failing in gtest_discover_tests with an ASan heap-buffer-overflow inside libc++'s vector reallocation path after Homebrew bumped llvm@22 from 22.1.2 to 22.1.3. Cached gtest/spdlog binaries were compiled against 22.1.2's libc++ headers while the application links against 22.1.3's libc++/ASan runtime. libc++'s public ABI is stable across patch bumps, but ASan's vector-annotation contract (header-emitted
__sanitizer_annotate_contiguous_container calls) is not - that drift produces the overflow report.

Encode the LLVM patch version into Conan's package_id for sanitizer builds only, so a Homebrew bump forces a rebuild of those dependencies:

- New optional setting compiler.clang.abi_extra in settings_user.yml
- New sanitizer-only profile conan-profile-clang-with-libc++-sanitizers that includes the base profile and sets compiler.abi_extra=sanitizers-${LLVM_FULL_VERSION}
- LLVM_FULL_VERSION resolved from brew list --versions and exported by the homebrew-packages-setup action
- Sanitizer CMake preset overrides CONAN_HOST_PROFILE to point at the new profile

Other matrix entries leave abi_extra unset, which Conan strips from package_id hashing, so their existing caches stay valid.