### PR TITLE
Replace sccache-action with in-repo sccache server management

### DIFF
--- a/.github/actions/cmake-project-setup/action.yaml
+++ b/.github/actions/cmake-project-setup/action.yaml
@@ -34,26 +34,14 @@ runs:
       # TODO: Install cmake through mise
       uses: lukka/get-cmake@7bfc9baacbbdcb5e37957ad05c3546b3e222be3c # v4.3.2
 
-    - id: sccache-version
-      run: |
-        # Determine sccache version
-        set -euo pipefail
-        pushd solvers/cpp
-        sccache_version=$(mise tool sccache --active | tr -d '\n')
-        echo "version=v${sccache_version}" | tee -a "${GITHUB_OUTPUT}"
-        popd
-      shell: bash
-
-    - name: Setup sccache
-      # TODO: Use sccache from mise when it's possible to avoid installing it via this action
-      uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+    - name: Configure and start sccache
+      env:
+        SCCACHE_GHA_ENABLED: "true"
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
-        version: ${{ steps.sccache-version.outputs.version }}
-
-    - run: |
-        # Enable sccache for C++
-        echo "SCCACHE_GHA_ENABLED=true" | tee -a "${GITHUB_ENV}"
-      shell: bash
+        script: |
+          const { execFileSync } = require('child_process');
+          execFileSync('sccache', ['--start-server'], { stdio: 'inherit' });
 
     - run: |
         # Prepare files

--- a/.github/workflows/cpp-build-test-run.yaml
+++ b/.github/workflows/cpp-build-test-run.yaml
@@ -161,6 +161,12 @@ jobs:
           AOC_CPP_WORKFLOW_PRESET: ${{ steps.preset-name.outputs.name }}
         run: mise run aoc:all -- --solver cpp
 
+      - continue-on-error: true
+        if: always()
+        name: sccache stats
+        run: sccache --show-stats
+        shell: bash
+
       - name: Finalize cmake project
         uses: ./.github/actions/cmake-project-finalize
         with:


### PR DESCRIPTION
sccache-action downloads a sccache binary on every CI run, causing flaky 502 failures from GitHub releases. The binary is redundant since mise already provides sccache.

Replacing it is non-trivial: the GHA cache backend credentials (`ACTIONS_CACHE_URL`, `ACTIONS_RUNTIME_TOKEN`) are only available in the Node.js runner process environment, not in regular shell steps. A `github-script` step starts the sccache server from within Node.js so it inherits these credentials directly from `process.env` — the same mechanism `sccache-action` used internally.

sccache lifecycle is encapsulated in the `cmake-project-*` composite actions: setup starts the server, the workflow reports stats via a dedicated always-running step.