### PR TITLE
Fix homebrew bottle-install crashes by aligning prepare/use jobs on upstream HEAD

### DIFF
--- a/.github/actions/homebrew-packages-setup/init.sh
+++ b/.github/actions/homebrew-packages-setup/init.sh
@@ -2,9 +2,10 @@
 
 set -euo pipefail
 
-# Isolate all 'brew' calls in this script from auto-update so the captured
-# Homebrew commit reflects the runner image exactly. The same value is also
-# written to GITHUB_ENV below for subsequent action steps.
+# Disable Homebrew's implicit auto-update on 'brew install'; we update
+# explicitly below so the captured Homebrew commit is the one we deliberately
+# advanced to, not one snuck in by auto-update mid-install. The same value is
+# also written to GITHUB_ENV below for subsequent action steps.
 export HOMEBREW_NO_AUTO_UPDATE=1
 
 # Ensure brew is in path. Needed on Ubuntu runner
@@ -38,9 +39,17 @@ toolsToInstallCacheKeyPart=$(
   echo "${toolsToInstall[*]}"
 )
 
-# Scope the cache key to the Homebrew commit currently on the runner.
-# Bottles downloaded under one Homebrew version may fail to install under
-# another, so a runner-image Homebrew bump must invalidate the cache.
+# Update Homebrew before capturing its commit. The runner-image Homebrew is
+# not guaranteed to be reliable for 'brew install' as-shipped, and both
+# prepare and use jobs need to converge on the same upstream HEAD so their
+# cache keys (and the bottles produced under them) match.
+echo "::group::Update brew formulae"
+brew update
+echo "::endgroup::"
+
+# Scope the cache key to the post-update Homebrew commit. Bottles downloaded
+# under one Homebrew version may fail to install under another, so any change
+# to the upstream commit we land on must invalidate the cache.
 brewRepository=$(brew --repository)
 brewCommit=$(git -C "${brewRepository}" rev-parse --short=12 HEAD)
 brewCommitCacheKeyPart="brew${brewCommit}"

--- a/.github/actions/homebrew-packages-setup/init.sh
+++ b/.github/actions/homebrew-packages-setup/init.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+# Isolate all 'brew' calls in this script from auto-update so the captured
+# Homebrew commit reflects the runner image exactly. The same value is also
+# written to GITHUB_ENV below for subsequent action steps.
+export HOMEBREW_NO_AUTO_UPDATE=1
+
 # Ensure brew is in path. Needed on Ubuntu runner
 if ! command -v brew &>/dev/null; then
   linuxHomebrewBin="/home/linuxbrew/.linuxbrew/bin"

--- a/.github/actions/homebrew-packages-setup/init.sh
+++ b/.github/actions/homebrew-packages-setup/init.sh
@@ -33,9 +33,16 @@ toolsToInstallCacheKeyPart=$(
   echo "${toolsToInstall[*]}"
 )
 
+# Scope the cache key to the Homebrew commit currently on the runner.
+# Bottles downloaded under one Homebrew version may fail to install under
+# another, so a runner-image Homebrew bump must invalidate the cache.
+brewRepository=$(brew --repository)
+brewCommit=$(git -C "${brewRepository}" rev-parse --short=12 HEAD)
+brewCommitCacheKeyPart="brew${brewCommit}"
+
 # Values for cache key and restore-keys
 cacheKeyBase="homebrew-${RUNNER_OS}"
-cacheKeyPrefix="${cacheKeyBase}-${toolsToInstallCacheKeyPart}-${toolsToInstallHash}"
+cacheKeyPrefix="${cacheKeyBase}-${brewCommitCacheKeyPart}-${toolsToInstallCacheKeyPart}-${toolsToInstallHash}"
 cacheKeyForRestore="${cacheKeyPrefix}"
 if [[ -n "${INPUT_DOWNLOADS_HASH_FROM_PREPARE}" ]]; then
   cacheKeyForRestore="${cacheKeyForRestore}-${INPUT_DOWNLOADS_HASH_FROM_PREPARE}"

--- a/.github/actions/homebrew-packages-setup/install.sh
+++ b/.github/actions/homebrew-packages-setup/install.sh
@@ -33,12 +33,6 @@ if [[ "${CACHE_HIT}" == "true" && "${INPUT_DOWNLOADS_HASH_FROM_PREPARE}" != "${i
 fi
 
 if [[ "${skipInstalls}" == "false" ]]; then
-  if [[ "${INPUT_CACHE_MODE}" == "prepare" ]]; then
-    echo "::group::Update brew formulae"
-    brew update
-    echo "::endgroup::"
-  fi
-
   for tool in ${TOOLS_TO_INSTALL}; do
     echo "::group::Install ${tool}"
     brew install --quiet "${tool}"


### PR DESCRIPTION
## Symptom

The `ci-solvers-cpp` Ubuntu build-test-run jobs were crashing in
`Utils::Bottles.load_tab` with `undefined method '[]' for nil` while
installing llvm@22's dependency chain (example: run [25851166884][1]).
The crash reproduced even on a fully fresh install with no cache.

## Root cause

The homebrew-packages-setup action splits work into a *prepare* job
(downloads bottles, populates the cache) and *use* jobs (restore cache,
install). Two interacting problems made the split unsound:

1. The runner-image Homebrew isn't always reliable for `brew install`
   as-shipped. On at least one common Ubuntu 24.04 image (brew commit
   `299ab19496df`), `brew install llvm@22` crashes mid-dependency-chain
   regardless of cache state. Homebrew's own backtrace hint — *"Do not
   report this issue until you've run `brew update` and tried again"* —
   turned out to be literal.

2. The cache key encoded only OS and tool list. Prepare ran `brew update`
   and downloaded bottles under the post-update Homebrew, then saved the
   cache; use jobs (which didn't update) restored those bottles and tried
   to pour them with the pre-update Homebrew, crashing in `load_tab`. The
   PR prefix-match optimization in `install.sh` amplified the staleness
   by reusing caches across runner-image Homebrew bumps.

## Fix

- Run `brew update` in `init.sh`, before capturing the Homebrew commit.
  Both prepare and use jobs converge on the same upstream HEAD before
  anything else reads brew state.
- Include the post-update Homebrew commit in the cache-key prefix
  (`brew<short-sha>`). Cache invalidation now tracks the Homebrew code
  that produced the bottles, so prefix matches across a Homebrew bump
  no longer reuse incompatible downloads.
- Export `HOMEBREW_NO_AUTO_UPDATE=1` early in `init.sh` so the
  deliberate `brew update` is the only thing that advances the commit;
  auto-update during `brew install` would otherwise sneak past after
  the cache key was already computed.

The cost is one `brew update` (~5–30s) per use job. `brew install`
itself stays cache-served whenever prepare and use jobs reach the same
upstream HEAD within a workflow run, which is the common case.