### PR TITLE
Allow renovate updates during night

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,7 +19,7 @@
   },
   postUpdateOptions: ["npmDedupe"],
   rebaseWhen: "behind-base-branch",
-  schedule: ["* 8-13 * * 2-4"], // Tuesday-Thursday, during working day
+  schedule: ["* 0-13 * * 2-4"], // Tuesday-Thursday, midnight through working day
   semanticCommits: "disabled",
   separateMinorPatch: true,
 
@@ -31,7 +31,7 @@
       automerge: true,
       minimumReleaseAge: "1 day", // 1 day delay to avoid errors installing very fresh version - https://github.com/jdx/mise/issues/2314
       prPriority: -1, // Lowest priority
-      schedule: ["* 8-13 * * 4"], // Thursday, during working day
+      schedule: ["* 0-13 * * 4"], // Thursday, midnight through working day
     },
     {
       description: "Automerge all updates",


### PR DESCRIPTION
This is hopefully enough to give renovate a better chance of getting executed during the update window.