### PR TITLE
Accept Homebrew revision suffix in LLVM version parsing

### DIFF
--- a/.github/actions/homebrew-packages-setup/install.sh
+++ b/.github/actions/homebrew-packages-setup/install.sh
@@ -50,7 +50,7 @@ if [[ "${skipInstalls}" == "false" ]]; then
     exit 1
   fi
   llvmFullVersion=$(echo "${brewLlvmListOutput}" | awk '{print $NF}')
-  if ! [[ "${llvmFullVersion}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  if ! [[ "${llvmFullVersion}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(_[0-9]+)?$ ]]; then
     echo "::error::Could not parse LLVM full version from: ${brewLlvmListOutput}"
     exit 1
   fi


### PR DESCRIPTION
Homebrew published llvm 22.1.7_1, where the trailing _1 is a bottle revision (a rebuild of the same upstream version). The version validation regex only accepted bare X.Y.Z, so it rejected the _N suffix and failed the "Setup homebrew packages" step in every C++ job.

Widen the regex to accept an optional _N revision suffix. The parsed value feeds compiler.abi_extra in the Conan sanitizers profile, so keeping the suffix is correct: a Homebrew rebuild should invalidate the Conan ABI discriminator and trigger a rebuild.