### PR TITLE
Replace repology datasource with custom Homebrew datasource

### DIFF
--- a/.github/actions/homebrew-packages-setup/action.yaml
+++ b/.github/actions/homebrew-packages-setup/action.yaml
@@ -30,9 +30,9 @@ runs:
         INPUT_CACHE_MODE: ${{ inputs.cache-mode }}
         INPUT_DOWNLOADS_HASH_FROM_PREPARE: ${{ inputs.downloads-hash-from-prepare }}
         # Major versions of GCC and LLVM to use
-        # renovate: datasource=repology depName=gcc packageName=homebrew/gcc extractVersion=^(?<version>\d+)\.\d+\.\d+$
+        # renovate: datasource=custom.homebrew depName=gcc extractVersion=^(?<version>\d+)\.\d+\.\d+$
         GCC_MAJOR_VERSION: 15
-        # renovate: datasource=repology depName=llvm packageName=homebrew/llvm extractVersion=^(?<version>\d+)\.\d+\.\d+$
+        # renovate: datasource=custom.homebrew depName=llvm extractVersion=^(?<version>\d+)\.\d+\.\d+$
         LLVM_MAJOR_VERSION: 22
       run: |
         # Initialize action

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,16 @@
   conan: {
     enabled: true,
   },
+  customDatasources: {
+    // Tracks the version Homebrew ships (not upstream releases, which land
+    // before Homebrew bottles exist), via https://formulae.brew.sh.
+    homebrew: {
+      defaultRegistryUrlTemplate: "https://formulae.brew.sh/api/formula/{{packageName}}.json",
+      transformTemplates: [
+        '{"releases": [{"version": versions.stable}], "homepage": homepage, "sourceUrl": urls.stable.url}',
+      ],
+    },
+  },
   "git-submodules": {
     enabled: true,
   },


### PR DESCRIPTION
repology.org aggressively rate-limits Renovate, so the gcc/llvm major
version lookups fail (renovatebot/renovate#38036). Replace the repology
datasource with a customDatasources entry that queries the Homebrew
formulae API (formulae.brew.sh) directly, which tracks exactly what
Homebrew ships and additionally provides homepage/source links for
Renovate PR bodies.