### PR TITLE
Collapse mise CalVer updates into a single Renovate branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,6 +42,10 @@
       minimumReleaseAge: "1 day", // 1 day delay to avoid errors installing very fresh version - https://github.com/jdx/mise/issues/2314
       prPriority: -1, // Lowest priority
       schedule: ["* 0-13 * * 4"], // Thursday, midnight through working day
+      // mise uses CalVer (YEAR.MONTH.COUNTER), not SemVer. Collapse the
+      // year/month/counter splits into one branch that tracks the latest release.
+      separateMajorMinor: false,
+      separateMinorPatch: false, // override repo-wide separateMinorPatch:true for mise
     },
     {
       description: "Automerge all updates",


### PR DESCRIPTION
mise uses CalVer (YEAR.MONTH.COUNTER), which Renovate maps onto SemVer major/minor/patch and splits into separate PRs: counter bumps as patch, month bumps as minor (both forked by the repo-wide separateMinorPatch), and year bumps as major (forked by separateMajorMinor's default).

Since mise is self-managed and we only want the latest release, set separateMajorMinor and separateMinorPatch to false on the mise package rule so every update converges into one branch tracking the newest version.