### PR TITLE
Ignore any .venv* directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/
-.venv/
+.venv*/
 __pycache__/
 
 /inputs/


### PR DESCRIPTION
Different variants of .venv* directories can be used for different environments. Ensure they are all ignored properly by git and by prettier.