### PR TITLE
Require clang + libstdc++ conan binaries per GCC major

### DIFF
--- a/.github/files/conan-profile-gcc-libstd++-for-clang
+++ b/.github/files/conan-profile-gcc-libstd++-for-clang
@@ -2,6 +2,9 @@
 {% set gccMajorVersion = os.environ["GCC_MAJOR_VERSION"] %}
 {% set gccPlat = {"Darwin": "aarch64-apple-darwin24", "Linux": "x86_64-pc-linux-gnu"}[platform.system()] %}
 
+[settings]
+compiler.abi_extra=libstdc++-gcc-{{ gccMajorVersion }}
+
 [conf]
 tools.build:cxxflags=["-stdlib++-isystem{{ prefix }}/opt/gcc@{{ gccMajorVersion }}/include/c++/{{ gccMajorVersion }}", "-cxx-isystem{{ prefix }}/opt/gcc@{{ gccMajorVersion }}/include/c++/{{ gccMajorVersion }}/{{ gccPlat }}"]
 tools.build:exelinkflags=["-stdlib=libstdc++", "-L{{ prefix }}/opt/gcc@{{ gccMajorVersion }}/lib/gcc/{{ gccMajorVersion }}"]


### PR DESCRIPTION
Add compiler.abi_extra setting to conan profile used for builds with clang using libstdc++ from gcc that differentiates built binaries based on GCC major version. This ensures that conan packages are rebuilt when GCC major version updates.