### PR TITLE
Layer conan profile addons on top of base profile

### DIFF
--- a/.github/files/CMakeUserPresets.json
+++ b/.github/files/CMakeUserPresets.json
@@ -176,7 +176,7 @@
         "CMAKE_CXX_FLAGS": "$env{PRESET_CXX_FLAGS_LIBCPP_FOR_CLANG}",
         "CMAKE_EXE_LINKER_FLAGS": "$env{PRESET_LINKER_FLAGS_LIBCPP_FOR_CLANG}",
         "CMAKE_SHARED_LINKER_FLAGS": "$env{PRESET_LINKER_FLAGS_LIBCPP_FOR_CLANG}",
-        "CONAN_HOST_PROFILE": "${sourceDir}/conan-profile-clang-with-libc++;auto-cmake"
+        "CONAN_HOST_PROFILE": "auto-cmake;${sourceDir}/conan-profile-clang-with-libc++"
       }
     },
     {
@@ -188,7 +188,7 @@
       "cacheVariables": {
         "CMAKE_EXE_LINKER_FLAGS": "-stdlib=libstdc++ -L$penv{HOMEBREW_PREFIX}/opt/gcc@$penv{GCC_MAJOR_VERSION}/lib/gcc/$penv{GCC_MAJOR_VERSION}",
         "CMAKE_SHARED_LINKER_FLAGS": "-stdlib=libstdc++ -L$penv{HOMEBREW_PREFIX}/opt/gcc@$penv{GCC_MAJOR_VERSION}/lib/gcc/$penv{GCC_MAJOR_VERSION}",
-        "CONAN_HOST_PROFILE": "${sourceDir}/conan-profile-gcc-libstd++-for-clang;auto-cmake"
+        "CONAN_HOST_PROFILE": "auto-cmake;${sourceDir}/conan-profile-gcc-libstd++-for-clang"
       }
     },
     {


### PR DESCRIPTION
CONAN_HOST_PROFILE is an ordered list where later profiles override earlier ones. auto-cmake is the base host profile generated from the CMake toolchain, and the clang/libstdc++ profile files are addons meant to extend it. They were listed before auto-cmake, so the generated base could override the addon settings. Put auto-cmake first so the custom addon profiles apply on top of it as intended.