### PR TITLE
Ignore ruff rule CPY001

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -8,6 +8,7 @@ select = ["ALL"]
 
 ignore = [
   "COM812",
+  "CPY001",
   "D10",
   "FIX",
   "ISC001",


### PR DESCRIPTION
Ruff 0.16 version stabilizes CPY001 rule that check for copyright notices at the top of every python file. This repository does not intend to have those so ignore the rule.