### PR TITLE
Require dependencies to be 14 days old before use

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,8 +4,10 @@
     "config:best-practices",
     ":pinAllExceptPeerDependencies",
     "customManagers:githubActionsVersions",
-    "security:minimumReleaseAgeNpm",
   ],
+  // Pulled in by config:best-practices, but it caps npm at 3 days from inside a
+  // packageRule, which would override the repo-wide minimumReleaseAge below.
+  ignorePresets: ["security:minimumReleaseAgeNpm"],
 
   commitHourlyLimit: 1,
   conan: {
@@ -27,6 +29,16 @@
   lockFileMaintenance: {
     enabled: true,
   },
+  // Every update here is automerged, so this delay is the only thing standing
+  // between a poisoned release and main. Renovate recommends 14 days when
+  // automerging third-party dependencies. Vulnerability fixes are exempt
+  // (vulnerabilityAlerts defaults to minimumReleaseAge:null), and any update can
+  // be pulled early from the Dependency Dashboard.
+  //
+  // Also covers the functional cases: mise errors when installing a very fresh
+  // release (https://github.com/jdx/mise/issues/2314) and CPython prebuilt
+  // binaries only appearing some time after the tag.
+  minimumReleaseAge: "14 days",
   postUpdateOptions: ["npmDedupe"],
   rebaseWhen: "behind-base-branch",
   schedule: ["* 0-13 * * 2-4"], // Tuesday-Thursday, midnight through working day
@@ -35,11 +47,34 @@
 
   packageRules: [
     {
+      description: "Update types that pull in no new upstream code, so release age does not apply",
+      matchUpdateTypes: [
+        "bump",
+        "lockFileMaintenance",
+        "lockfileUpdate",
+        "pin",
+        "replacement",
+        "rollback",
+      ],
+
+      minimumReleaseAge: null,
+    },
+    {
+      description: "Datasources that publish no per-version timestamp cannot be aged",
+      matchDatasources: ["conan", "custom.homebrew", "git-refs"],
+
+      // Without this these are held indefinitely, since
+      // minimumReleaseAgeBehaviour defaults to timestamp-required. Conan Center
+      // does publish a timestamp per recipe revision, but only on a per-version
+      // URL the conan datasource does not read; conan.lock pins those revisions
+      // by content hash instead. formulae.brew.sh exposes no version timestamp.
+      minimumReleaseAge: null,
+    },
+    {
       description: "Mise package settings",
       matchPackageNames: ["jdx/mise"],
 
       automerge: true,
-      minimumReleaseAge: "1 day", // 1 day delay to avoid errors installing very fresh version - https://github.com/jdx/mise/issues/2314
       prPriority: -1, // Lowest priority
       schedule: ["* 0-13 * * 4"], // Thursday, midnight through working day
       // mise uses CalVer (YEAR.MONTH.COUNTER), not SemVer. Collapse the
@@ -58,12 +93,6 @@
       ],
 
       automerge: true,
-    },
-    {
-      description: "Python prebuilt binaries take some time to be available. Delay python updates.",
-      matchManagers: ["mise"],
-      matchPackageNames: ["python/cpython"],
-      minimumReleaseAge: "1 week",
     },
     {
       description: "Don't pin requires-python in pyproject.toml files",

--- a/aoc-main/pyproject.toml
+++ b/aoc-main/pyproject.toml
@@ -34,3 +34,13 @@ extend = "../ruff.toml"
 [tool.ruff.lint.extend-per-file-ignores]
 "src/aoc_main/main.py" = ["T201"]
 "tests/**/*.py" = ["INP001"]
+
+[tool.uv]
+# Gates transitive dependencies, which Renovate's minimumReleaseAge cannot reach
+# through lockFileMaintenance. Kept equal to that window so no dependency enters
+# by any path before it has been public for 14 days.
+#
+# Direct dependencies are pinned with ==, so a pin younger than this window
+# resolves to nothing rather than merely waiting: forcing an update early from
+# Renovate's Dependency Dashboard fails here with "no solution found".
+exclude-newer = "14 days"

--- a/aoc-main/uv.lock
+++ b/aoc-main/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P14D"
+
 [[package]]
 name = "aoc-main"
 version = "0.1.0"

--- a/solvers/python/pyproject.toml
+++ b/solvers/python/pyproject.toml
@@ -29,3 +29,13 @@ extend = "../../ruff.toml"
 
 [tool.ruff.lint.extend-per-file-ignores]
 "tests/**/*.py" = ["INP001"]
+
+[tool.uv]
+# Gates transitive dependencies, which Renovate's minimumReleaseAge cannot reach
+# through lockFileMaintenance. Kept equal to that window so no dependency enters
+# by any path before it has been public for 14 days.
+#
+# Direct dependencies are pinned with ==, so a pin younger than this window
+# resolves to nothing rather than merely waiting: forcing an update early from
+# Renovate's Dependency Dashboard fails here with "no solution found".
+exclude-newer = "14 days"

--- a/solvers/python/uv.lock
+++ b/solvers/python/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P14D"
+
 [[package]]
 name = "aoc"
 version = "0.1.0"


### PR DESCRIPTION
Registries expose new versions for resolution immediately, and the 2026 npm
and PyPI compromises followed a consistent pattern: a stolen publishing
token pushes a malicious version, the payload runs at install time and
harvests credentials from the machine doing the install, and the registry
pulls the version within hours. Every update here is automerged, so this
delay replaces the human review that would otherwise be the backstop.
Vulnerability fixes are unaffected, since vulnerabilityAlerts defaults to
minimumReleaseAge:null, and any update can still be pulled early from the
Dependency Dashboard.

Apply minimumReleaseAge repo wide instead of to npm alone, and ignore
security:minimumReleaseAgeNpm, which config:best-practices pulls in and
which would cap npm at 3 days from inside a packageRule. Exempt the update
types that pull in no new upstream code, and the conan, custom.homebrew and
git-refs datasources, which publish no per-version timestamp and would
otherwise be held indefinitely by minimumReleaseAgeBehaviour defaulting to
timestamp-required. Drop the mise and python/cpython delays, as both were
shorter than the repo wide window that now covers their original purpose.

Set uv's exclude-newer to the same 14 days. minimumReleaseAge cannot gate
lockFileMaintenance, since a lock refresh has no single version to age, so
this is what holds transitive dependencies to the same window.