### PR TITLE
Enable sccache client-side mode for C++ builds

### DIFF
--- a/solvers/cpp/mise.toml
+++ b/solvers/cpp/mise.toml
@@ -4,6 +4,9 @@
 conan = "2.31.2"
 sccache = "0.17.0"
 
+[env]
+SCCACHE_CLIENT_SIDE = "true"
+
 [tasks.check]
 depends = [
   "check:clang-format",


### PR DESCRIPTION
sccache 0.17.0 added an opt-in mode where the compile pipeline runs in the CLI process instead of round-tripping through the background daemon for every translation unit, removing a serialization point under parallel builds. It's exported to both local dev shells and CI via mise's [env] table, since mise-action already forwards it to GITHUB_ENV.