### PR TITLE
Show full task commands in CI mise logs

### DIFF
--- a/.github/actions/mise-project-setup/init.sh
+++ b/.github/actions/mise-project-setup/init.sh
@@ -63,6 +63,7 @@ echo "::group::Environment variable changes"
   echo
 
   echo "MISE_DEBUG=1"
+  echo "MISE_TASK_SHOW_FULL_CMD=true"
   echo "RUST_LOG=uv=debug"
 } | tee -a "${GITHUB_ENV}"
 echo "::endgroup::"


### PR DESCRIPTION
mise abbreviates the command it echoes when running a task: a multi-line `run` script collapses to its first meaningful line, and a long single-line command is truncated to terminal width. CI logs therefore never show the script that actually ran, nor which paths a linter was pointed at.

Export MISE_TASK_SHOW_FULL_CMD from the mise setup action so every subsequent `mise run` step prints the full command, alongside the existing MISE_DEBUG verbosity.