### PR TITLE
Derive the C++ CI build matrix from its config generator

### DIFF
--- a/.github/scripts/generate-cpp-ci-config.py
+++ b/.github/scripts/generate-cpp-ci-config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate concrete C++ CI configuration for one workflow matrix entry."""
+"""Generate the C++ CI build matrix and the configuration for one matrix entry."""
 
 from __future__ import annotations
 
@@ -9,10 +9,38 @@ import os
 import shlex
 import sys
 from pathlib import Path
-from typing import Final
+from typing import Final, NamedTuple
 
 _REPOSITORY_ROOT: Final = Path(__file__).resolve().parents[2]
 _CPP_DIR: Final = _REPOSITORY_ROOT / "solvers" / "cpp"
+
+
+class _MatrixEntry(NamedTuple):
+    """One C++ build scenario: which compiler, standard library and build type."""
+
+    os: str
+    compiler: str
+    cxx_lib: str
+    build_type: str
+
+
+# Runner image hosting each operating system.
+_RUNNERS: Final = {"macos": "macos-15", "ubuntu": "ubuntu-24.04"}
+
+# Every scenario CI builds. The workflow obtains its job list from the `matrix`
+# subcommand rather than declaring one, so this table is the only place the set of
+# scenarios is written down and the two cannot drift apart.
+_MATRIX: Final = (
+    _MatrixEntry("ubuntu", "clang", "libc++", "debug"),
+    _MatrixEntry("ubuntu", "clang", "libc++", "release"),
+    _MatrixEntry("ubuntu", "clang", "libc++", "sanitizers"),
+    _MatrixEntry("ubuntu", "clang", "libc++", "hardened"),
+    _MatrixEntry("ubuntu", "clang", "libstdc++", "debug"),
+    _MatrixEntry("ubuntu", "clang", "libstdc++", "release"),
+    _MatrixEntry("ubuntu", "gcc", "libstdc++", "debug"),
+    _MatrixEntry("ubuntu", "gcc", "libstdc++", "release"),
+    _MatrixEntry("macos", "clang", "libstdc++", "release"),
+)
 
 
 class ConfigurationError(ValueError):
@@ -29,7 +57,7 @@ class MissingEnvironmentError(ConfigurationError):
 class UnsupportedMatrixError(ConfigurationError):
     """Raised when the workflow matrix specifies an unsupported build."""
 
-    def __init__(self, matrix: tuple[str, str, str, str]) -> None:
+    def __init__(self, matrix: _MatrixEntry) -> None:
         super().__init__(f"Unsupported C++ CI matrix entry: {', '.join(matrix)}")
 
 
@@ -41,20 +69,24 @@ def _required_environment(name: str) -> str:
 
 
 def _validate_matrix(args: argparse.Namespace) -> None:
-    valid = {
-        ("ubuntu", "clang", "libc++", "debug"),
-        ("ubuntu", "clang", "libc++", "release"),
-        ("ubuntu", "clang", "libc++", "sanitizers"),
-        ("ubuntu", "clang", "libc++", "hardened"),
-        ("ubuntu", "clang", "libstdc++", "debug"),
-        ("ubuntu", "clang", "libstdc++", "release"),
-        ("ubuntu", "gcc", "libstdc++", "debug"),
-        ("ubuntu", "gcc", "libstdc++", "release"),
-        ("macos", "clang", "libstdc++", "release"),
-    }
-    matrix = (args.os, args.compiler, args.cxx_lib, args.build_type)
-    if matrix not in valid:
+    matrix = _MatrixEntry(args.os, args.compiler, args.cxx_lib, args.build_type)
+    if matrix not in _MATRIX:
         raise UnsupportedMatrixError(matrix)
+
+
+def _github_include(
+    entry: _MatrixEntry, homebrew_hashes: dict[str, str]
+) -> dict[str, str]:
+    # Key names are read by the workflow's job name, `if:` conditions and step
+    # environments, so they follow GitHub's casing rather than Python's.
+    return {
+        "os": entry.os,
+        "compiler": entry.compiler,
+        "cxxLib": entry.cxx_lib,
+        "buildType": entry.build_type,
+        "runsOn": _RUNNERS[entry.os],
+        "homebrew-downloads-hash-from-prepare": homebrew_hashes[entry.os],
+    }
 
 
 def _profile_path() -> str:
@@ -334,19 +366,52 @@ def _write_environment(path: Path, args: argparse.Namespace) -> None:
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--os", choices=("ubuntu", "macos"), required=True)
-    parser.add_argument("--compiler", choices=("clang", "gcc"), required=True)
-    parser.add_argument("--cxx-lib", choices=("libc++", "libstdc++"), required=True)
-    parser.add_argument(
-        "--build-type",
-        choices=("debug", "release", "sanitizers", "hardened"),
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    config = subparsers.add_parser(
+        "config", help="Write the CMake, environment and Conan files for one entry"
+    )
+    config.add_argument(
+        "--os", choices=sorted({entry.os for entry in _MATRIX}), required=True
+    )
+    config.add_argument(
+        "--compiler",
+        choices=sorted({entry.compiler for entry in _MATRIX}),
         required=True,
     )
+    config.add_argument(
+        "--cxx-lib",
+        choices=sorted({entry.cxx_lib for entry in _MATRIX}),
+        required=True,
+    )
+    config.add_argument(
+        "--build-type",
+        choices=sorted({entry.build_type for entry in _MATRIX}),
+        required=True,
+    )
+    config.add_argument("--output-dir", default=_CPP_DIR, type=Path)
+
+    matrix = subparsers.add_parser(
+        "matrix", help="Print the workflow build matrix as JSON"
+    )
+    # Defaulted rather than required: `workflow_dispatch` runs supply no hashes.
+    matrix.add_argument("--homebrew-downloads-hash-macos", default="")
+    matrix.add_argument("--homebrew-downloads-hash-ubuntu", default="")
+
     return parser.parse_args()
 
 
-def main() -> int:
-    args = _parse_args()
+def _emit_matrix(args: argparse.Namespace) -> None:
+    homebrew_hashes = {
+        "macos": args.homebrew_downloads_hash_macos,
+        "ubuntu": args.homebrew_downloads_hash_ubuntu,
+    }
+    include = [_github_include(entry, homebrew_hashes) for entry in _MATRIX]
+    # One line, so the caller can assign it to a `$GITHUB_OUTPUT` variable.
+    print(json.dumps({"include": include}))
+
+
+def _write_configuration(args: argparse.Namespace) -> int:
     try:
         _validate_matrix(args)
         cache_variables, conan_profile = _configuration(args)
@@ -365,12 +430,22 @@ def main() -> int:
             }
         ],
     }
-    (_CPP_DIR / "CMakeUserPresets.json").write_text(
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "CMakeUserPresets.json").write_text(
         json.dumps(preset, indent=2) + "\n", encoding="utf-8"
     )
-    _write_environment(_CPP_DIR / "ci.env", args)
-    (_CPP_DIR / "conan-profile-ci").write_text(conan_profile, encoding="utf-8")
+    _write_environment(output_dir / "ci.env", args)
+    (output_dir / "conan-profile-ci").write_text(conan_profile, encoding="utf-8")
     return 0
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.command == "matrix":
+        _emit_matrix(args)
+        return 0
+    return _write_configuration(args)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/cpp-build-test-run.yaml
+++ b/.github/workflows/cpp-build-test-run.yaml
@@ -15,51 +15,44 @@ permissions:
   contents: read
 
 jobs:
+  # The generator that configures each build owns the list of builds too
+  matrix:
+    name: Resolve build matrix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup tools through mise
+        uses: ./.github/actions/mise-project-setup
+        with:
+          directory: .
+
+      - id: matrix
+        name: Generate build matrix
+
+        env:
+          HOMEBREW_HASH_MACOS: ${{ inputs.homebrew-downloads-hash-from-prepare-macos }}
+          HOMEBREW_HASH_UBUNTU: ${{ inputs.homebrew-downloads-hash-from-prepare-ubuntu }}
+        run: |
+          matrix=$(python3 .github/scripts/generate-cpp-ci-config.py matrix \
+            --homebrew-downloads-hash-macos "${HOMEBREW_HASH_MACOS}" \
+            --homebrew-downloads-hash-ubuntu "${HOMEBREW_HASH_UBUNTU}")
+          echo "matrix=${matrix}" | tee -a "${GITHUB_OUTPUT}"
+        shell: bash
+
   build-test-run:
     strategy:
       fail-fast: false
-      matrix:
-        os:
-          - ubuntu
-        compiler:
-          - clang
-          - gcc
-        cxxLib:
-          - libc++
-          - libstdc++
-        buildType:
-          - debug
-          - release
-        exclude:
-          - compiler: gcc
-            cxxLib: libc++
-        include:
-          - os: ubuntu
-            homebrew-downloads-hash-from-prepare: ${{ inputs.homebrew-downloads-hash-from-prepare-ubuntu }}
-            runsOn: ubuntu-24.04
-
-          - os: ubuntu
-            compiler: clang
-            cxxLib: libc++
-            buildType: sanitizers
-            homebrew-downloads-hash-from-prepare: ${{ inputs.homebrew-downloads-hash-from-prepare-ubuntu }}
-            runsOn: ubuntu-24.04
-
-          - os: ubuntu
-            compiler: clang
-            cxxLib: libc++
-            buildType: hardened
-            homebrew-downloads-hash-from-prepare: ${{ inputs.homebrew-downloads-hash-from-prepare-ubuntu }}
-            runsOn: ubuntu-24.04
-
-          - os: macos
-            compiler: clang
-            cxxLib: libstdc++
-            buildType: release
-            homebrew-downloads-hash-from-prepare: ${{ inputs.homebrew-downloads-hash-from-prepare-macos }}
-            runsOn: macos-15
+      matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
 
     name: ${{ matrix.os }} ${{ matrix.compiler }} ${{ matrix.cxxLib }} ${{ matrix.buildType }} - Build + test + run
+    needs: matrix
     runs-on: ${{ matrix.runsOn }}
     timeout-minutes: 30
 
@@ -140,7 +133,7 @@ jobs:
           MATRIX_CXXLIB: ${{ matrix.cxxLib }}
           MATRIX_OS: ${{ matrix.os }}
         run: |
-          python3 .github/scripts/generate-cpp-ci-config.py \
+          python3 .github/scripts/generate-cpp-ci-config.py config \
             --os "${MATRIX_OS}" \
             --compiler "${MATRIX_COMPILER}" \
             --cxx-lib "${MATRIX_CXXLIB}" \


### PR DESCRIPTION
The set of build scenarios (os x compiler x cxxLib x buildType) was written out twice: as a `strategy.matrix` in cpp-build-test-run.yaml, and again as the `valid` set in generate-cpp-ci-config.py, with the argparse choices restating the axes a third time. Nothing enforced agreement. The script is only ever invoked from a matrix job, it has no tests, and neither ruff nor pyright can see across the YAML/Python boundary, so adding a row without editing the Python failed with "Unsupported C++ CI matrix entry" at job runtime, after checkout, Homebrew restore, mise setup and Conan cache restore had already spent minutes.

The generator now owns the table and emits it as JSON through a new `matrix` subcommand. A small resolver job feeds that to the build job through GitHub's dynamic-matrix mechanism, so the workflow no longer declares combinations at all. Every job becomes an explicit row, which also retires the augment-vs-add subtlety of the bare `- os: ubuntu` include that expanded the six base combinations rather than adding a tenth job.

Generation itself is unchanged: CMakeUserPresets.json, ci.env and conan-profile-ci come out byte-identical for all nine entries. The new --output-dir exists so the generator can be exercised without overwriting a developer's own solvers/cpp/CMakeUserPresets.json, which is the include entry point for their per-host presets.