### PR TITLE
Identify C++ CI matrix jobs with a generated runId

### DIFF
--- a/.github/scripts/generate-cpp-ci-config.py
+++ b/.github/scripts/generate-cpp-ci-config.py
@@ -81,8 +81,9 @@ def _github_include(
     # environments, so they follow GitHub's casing rather than Python's.
     #
     # `runId` identifies one matrix job among all of them, for uses such as
-    # per-scenario cache keys. Joining every field keeps it unique by construction,
-    # including if the entry ever grows another axis.
+    # per-scenario cache keys. Joining every field carries a new axis into it
+    # automatically; `_emit_matrix` checks that the results stay distinct, since
+    # joining can alias if an axis value ever contains the separator.
     return {
         "os": entry.os,
         "compiler": entry.compiler,
@@ -412,6 +413,11 @@ def _emit_matrix(args: argparse.Namespace) -> None:
         "ubuntu": args.homebrew_downloads_hash_ubuntu,
     }
     include = [_github_include(entry, homebrew_hashes) for entry in _MATRIX]
+    # Two jobs sharing a runId would quietly share one Conan cache bucket, each
+    # restoring the other's packages and rebuilding anyway. Nothing downstream
+    # would fail, so catch it here.
+    run_ids = {entry["runId"] for entry in include}
+    assert len(run_ids) == len(include), "runId values are not unique"
     # One line, so the caller can assign it to a `$GITHUB_OUTPUT` variable.
     print(json.dumps({"include": include}))
 

--- a/.github/scripts/generate-cpp-ci-config.py
+++ b/.github/scripts/generate-cpp-ci-config.py
@@ -79,11 +79,16 @@ def _github_include(
 ) -> dict[str, str]:
     # Key names are read by the workflow's job name, `if:` conditions and step
     # environments, so they follow GitHub's casing rather than Python's.
+    #
+    # `runId` identifies one matrix job among all of them, for uses such as
+    # per-scenario cache keys. Joining every field keeps it unique by construction,
+    # including if the entry ever grows another axis.
     return {
         "os": entry.os,
         "compiler": entry.compiler,
         "cxxLib": entry.cxx_lib,
         "buildType": entry.build_type,
+        "runId": "-".join(entry),
         "runsOn": _RUNNERS[entry.os],
         "homebrew-downloads-hash-from-prepare": homebrew_hashes[entry.os],
     }

--- a/.github/workflows/cpp-build-test-run.yaml
+++ b/.github/workflows/cpp-build-test-run.yaml
@@ -57,19 +57,6 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - id: preset-name
-        name: Define workflow preset name
-
-        env:
-          MATRIX_BUILDTYPE: ${{ matrix.buildType }}
-          MATRIX_COMPILER: ${{ matrix.compiler }}
-          MATRIX_CXXLIB: ${{ matrix.cxxLib }}
-          MATRIX_OS: ${{ matrix.os }}
-        run: |
-          name="ci-${MATRIX_OS}-${MATRIX_COMPILER}-${MATRIX_CXXLIB}-${MATRIX_BUILDTYPE}"
-          echo "name=${name}" | tee -a "${GITHUB_OUTPUT}"
-        shell: bash
-
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -90,7 +77,7 @@ jobs:
         name: Setup CMake project
         uses: ./.github/actions/cmake-project-setup
         with:
-          conan-cache-key-prefix: conan-${{ steps.preset-name.outputs.name }}
+          conan-cache-key-prefix: conan-${{ matrix.runId }}
 
       - if: matrix.os == 'ubuntu'
         name: Specify HOMEBREW_PREFIX
@@ -225,5 +212,5 @@ jobs:
       - name: Finalize cmake project
         uses: ./.github/actions/cmake-project-finalize
         with:
-          conan-cache-key-prefix: conan-${{ steps.preset-name.outputs.name }}
+          conan-cache-key-prefix: conan-${{ matrix.runId }}
           conan-cache-matched-key: ${{ steps.setup-cmake-project.outputs.conan-cache-matched-key }}


### PR DESCRIPTION
The `preset-name` step built a string per matrix job by reassembling the four axes in shell. Its name no longer described it: the CMake preset is the literal `ci`, and the string's only consumers are the Conan cache key prefixes in cmake-project-setup and cmake-project-finalize. Now that the generator emits the matrix, the same value can come from the entry it already describes, so the step is redundant.

Add a `runId` field, joining every field of the entry so it stays unique by construction even if the matrix grows another axis, and read it as `conan-${{ matrix.runId }}` where the cache prefix is needed. The prefixes must stay distinct per scenario: cmake-project-setup falls back to restoring on the bare prefix, so a shared one would have every job pull a sibling configuration's packages, miss on package_id and rebuild from source anyway.

The vestigial `ci-` infix is dropped, since it described the preset name this string no longer is. That changes every prefix, so the existing Conan caches are orphaned and the first run rebuilds from source before saving under the new keys.