### PR TITLE
Run cpp:verify-runtime-stdlib task from any dir

### DIFF
--- a/mise-tasks/cpp/verify-runtime-stdlib.py
+++ b/mise-tasks/cpp/verify-runtime-stdlib.py
@@ -210,7 +210,8 @@ def _verify(binaries: list[Path], sonames: list[str], expected_prefix: str) -> b
 def main() -> bool:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-    build_dir = Path(os.environ["usage_build_dir"])  # noqa: SIM112
+    cwd = Path(os.environ["MISE_ORIGINAL_CWD"])
+    build_dir = cwd / Path(os.environ["usage_build_dir"])  # noqa: SIM112
     stdlib = os.environ["usage_stdlib"]  # noqa: SIM112
     expected_prefix = os.environ["usage_expected_prefix"].rstrip("/")  # noqa: SIM112
 


### PR DESCRIPTION
Previously the build dir provided to cpp:verify-runtime-stdlib mise task had to be relative to the repository root. This made it difficult to use as such relative paths are typically easier to provide relative to current working directory where tab completion for paths also works properly.

This change resolves the build-dir provided to cpp:verify-runtime-stdlib as relative to the users current working directory.