### PR TITLE
Rebuild Conan packages against a rebuilt hardened libc++

### DIFF
--- a/.github/actions/hardened-libc++/action.yaml
+++ b/.github/actions/hardened-libc++/action.yaml
@@ -7,6 +7,9 @@ inputs:
     required: true
 
 outputs:
+  abi-tag:
+    description: "Identity of the hardened libc++ build; its cache key doubles as an ABI tag"
+    value: ${{ steps.cache-restore.outputs.cache-primary-key }}
   install-dir:
     description: "Path to the installed hardened libc++"
     value: ${{ steps.init.outputs.installDir }}

--- a/.github/scripts/generate-cpp-ci-config.py
+++ b/.github/scripts/generate-cpp-ci-config.py
@@ -190,6 +190,7 @@ def _hardened_libcxx_configuration(
 ) -> tuple[dict[str, str], _ConanProfile]:
     llvm_major_version = _required_environment("LLVM_MAJOR_VERSION")
     llvm_prefix = f"{homebrew_prefix}/opt/llvm@{llvm_major_version}"
+    hardened_abi_tag = _required_environment("HARDENED_ABI_TAG")
     hardened_libcxx_dir = _required_environment("HARDENED_LIBCXX_DIR")
     _add_clang_compilers(cache_variables, llvm_prefix)
     libcxx_flags = f"-stdlib++-isystem{hardened_libcxx_dir}/include/c++/v1"
@@ -215,8 +216,14 @@ def _hardened_libcxx_configuration(
             "CMAKE_SHARED_LINKER_FLAGS": cmake_linker_flags,
         }
     )
+    # The hardened libc++ installs to a fixed path, so every flag above stays
+    # identical when a new one is built there. The tag is the only thing that
+    # separates dependencies built against one libc++ from another; its value is
+    # that build's cache key, so the two decisions cannot drift apart.
     profile = _ConanProfile(
-        cxxflags=(libcxx_flags, *hardening_flags), linkflags=conan_linker_flags
+        abi_tag=hardened_abi_tag,
+        cxxflags=(libcxx_flags, *hardening_flags),
+        linkflags=conan_linker_flags,
     )
     return cache_variables, profile
 

--- a/.github/workflows/cpp-build-test-run.yaml
+++ b/.github/workflows/cpp-build-test-run.yaml
@@ -100,12 +100,21 @@ jobs:
           llvm-major-version: ${{ env.LLVM_MAJOR_VERSION }}
 
       - if: matrix.cxxLib == 'libc++' && matrix.buildType == 'hardened'
-        name: Set env to hardened libc++ install dir for CMake and Conan configs
+        name: Set env vars from hardened libc++ for configuration generation
 
         env:
+          HARDENED_ABI_TAG: ${{ steps.setup-hardened-libcxx.outputs.abi-tag }}
           HARDENED_LIBCXX_DIR: ${{ steps.setup-hardened-libcxx.outputs.install-dir }}
         run: |
-          echo "HARDENED_LIBCXX_DIR=${HARDENED_LIBCXX_DIR}" | tr -d '\n' >> "${GITHUB_ENV}"
+          set -euo pipefail
+
+          {
+            echo "HARDENED_ABI_TAG=${HARDENED_ABI_TAG}"
+
+            echo -n "HARDENED_LIBCXX_DIR="
+            echo "${HARDENED_LIBCXX_DIR}" | tr -d '\n'
+            echo
+          } | tee -a "${GITHUB_ENV}"
         shell: bash
 
       - if: matrix.buildType == 'sanitizers'


### PR DESCRIPTION
The hardened libc++ installs to a fixed path under RUNNER_TEMP, so every flag the hardened entry puts in its profile — the -isystem include path, the -L library path, the hardening macros — is byte-identical whatever libc++ sits there. Its cache key is not: it covers the LLVM version, the Homebrew LLVM major version and build.sh, whose LIBCXX_ABI_DEFINES turn on bounded iterators in vector, string and array. A key change rebuilds libc++ into that same path while package_id sees nothing move, so the restored dependency binaries stay. The application then links objects built against two different libc++ ABIs, silently.

Tag the hardened profile with the user.aoc:abi conf, the same conf the sanitizers entry already uses for toolchain identity the flags do not spell out. tools.info.package_id:confs picks it up along with the rest, so nothing further is needed on the Conan side.

The tag's value is the libc++ cache key itself, carried out of the action as an output. The string that decides whether libc++ is rebuilt and the string that decides whether its dependents are rebuilt are then one and the same, and cannot drift apart.

Only the hardened matrix entry changes; its dependencies rebuild once.